### PR TITLE
Change module name performant-labs/qa_accounts and

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,8 @@
 {
-    "name": "drupal/qa_accounts",
+    "name": "performant-labs/qa_accounts",
+    "replace": {
+        "drupal/qa_accounts": "^1.0"
+    },
     "type": "drupal-module",
     "description": "Creates dummy accounts to aid in testing. Never enable in production environments.",
     "license": "GPL-2.0-or-later",


### PR DESCRIPTION
mark it to replace drupal/qa_accounts